### PR TITLE
Fix ifdefs for compiling on Linux

### DIFF
--- a/kaudio/io_oss.cpp
+++ b/kaudio/io_oss.cpp
@@ -14,7 +14,7 @@
 #else// defined(ENABLE_COMPAT) && defined(ENABLE_PULSE)
 
 // Linux/OSS includes
-#ifdef linux
+#ifdef __linux__
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>

--- a/kdm/sessreg.c
+++ b/kdm/sessreg.c
@@ -74,7 +74,7 @@
 # include	<pwd.h>
 #endif
 
-#ifdef linux
+#ifdef __linux__
 #define SYSV
 #endif
 


### PR DESCRIPTION
Corrected #ifdefs for Linux systems in KDM and KAudio